### PR TITLE
Update Client to Handle Text/String Error Responses

### DIFF
--- a/client.go
+++ b/client.go
@@ -242,19 +242,42 @@ func (c *Client) fullURL(suffix string, args ...any) string {
 }
 
 func (c *Client) handleErrorResp(resp *http.Response) error {
-	var errRes ErrorResponse
-	err := json.NewDecoder(resp.Body).Decode(&errRes)
-	if err != nil || errRes.Error == nil {
-		reqErr := &RequestError{
-			HTTPStatusCode: resp.StatusCode,
-			Err:            err,
-		}
-		if errRes.Error != nil {
-			reqErr.Err = errRes.Error
-		}
-		return reqErr
-	}
+	contentType := resp.Header.Get("Content-Type")
+	mainContentType := strings.Split(contentType, ";")[0]
+	mainContentType = strings.ToLower(strings.TrimSpace(mainContentType))
 
-	errRes.Error.HTTPStatusCode = resp.StatusCode
-	return errRes.Error
+	switch mainContentType {
+	case "application/json":
+		var errRes ErrorResponse
+		err := json.NewDecoder(resp.Body).Decode(&errRes)
+		if err != nil || errRes.Error == nil {
+			reqErr := &RequestError{
+				HTTPStatusCode: resp.StatusCode,
+				Err:            err,
+			}
+			if errRes.Error != nil {
+				reqErr.Err = errRes.Error
+			}
+			return reqErr
+		}
+
+		errRes.Error.HTTPStatusCode = resp.StatusCode
+		return errRes.Error
+	case "text/plain":
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+
+		return &RequestError{
+			HTTPStatusCode: resp.StatusCode,
+			Err:            fmt.Errorf("%s", body),
+		}
+	default:
+		return &RequestError{
+			HTTPStatusCode: resp.StatusCode,
+			Err:            fmt.Errorf("unexpected content type: %s", contentType),
+		}
+	}
 }

--- a/client.go
+++ b/client.go
@@ -153,7 +153,7 @@ func sendRequestStream[T streamable](client *Client, req *http.Request) (*stream
 	req.Header.Set("Cache-Control", "no-cache")
 	req.Header.Set("Connection", "keep-alive")
 
-	resp, err := client.config.HTTPClient.Do(req)
+	resp, err := client.config.HTTPClient.Do(req) //nolint:bodyclose // body is closed in stream.Close()
 	if err != nil {
 		return new(streamReader[T]), err
 	}

--- a/client.go
+++ b/client.go
@@ -153,7 +153,7 @@ func sendRequestStream[T streamable](client *Client, req *http.Request) (*stream
 	req.Header.Set("Cache-Control", "no-cache")
 	req.Header.Set("Connection", "keep-alive")
 
-	resp, err := client.config.HTTPClient.Do(req) //nolint:bodyclose // body is closed in stream.Close()
+	resp, err := client.config.HTTPClient.Do(req)
 	if err != nil {
 		return new(streamReader[T]), err
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -1,422 +1,283 @@
-package openai //nolint:testpackage // testing private field
+package openai
 
 import (
-	"bytes"
+	"bufio"
 	"context"
-	"errors"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
-	"reflect"
-	"testing"
+	"strings"
 
-	"github.com/odannyc/go-openai/internal/test"
-	"github.com/odannyc/go-openai/internal/test/checks"
+	utils "github.com/odannyc/go-openai/internal"
 )
 
-var errTestRequestBuilderFailed = errors.New("test request builder failed")
+// Client is OpenAI GPT-3 API client.
+type Client struct {
+	config ClientConfig
 
-type failingRequestBuilder struct{}
-
-func (*failingRequestBuilder) Build(_ context.Context, _, _ string, _ any, _ http.Header) (*http.Request, error) {
-	return nil, errTestRequestBuilderFailed
+	requestBuilder    utils.RequestBuilder
+	createFormBuilder func(io.Writer) utils.FormBuilder
 }
 
-func TestClient(t *testing.T) {
-	const mockToken = "mock token"
-	client := NewClient(mockToken)
-	if client.config.authToken != mockToken {
-		t.Errorf("Client does not contain proper token")
-	}
+type Response interface {
+	SetHeader(http.Header)
+}
 
-	const mockOrg = "mock org"
-	client = NewOrgClient(mockToken, mockOrg)
-	if client.config.authToken != mockToken {
-		t.Errorf("Client does not contain proper token")
-	}
-	if client.config.OrgID != mockOrg {
-		t.Errorf("Client does not contain proper orgID")
+type httpHeader http.Header
+
+func (h *httpHeader) SetHeader(header http.Header) {
+	*h = httpHeader(header)
+}
+
+func (h *httpHeader) Header() http.Header {
+	return http.Header(*h)
+}
+
+func (h *httpHeader) GetRateLimitHeaders() RateLimitHeaders {
+	return newRateLimitHeaders(h.Header())
+}
+
+// NewClient creates new OpenAI API client.
+func NewClient(authToken string) *Client {
+	config := DefaultConfig(authToken)
+	return NewClientWithConfig(config)
+}
+
+// NewClientWithConfig creates new OpenAI API client for specified config.
+func NewClientWithConfig(config ClientConfig) *Client {
+	return &Client{
+		config:         config,
+		requestBuilder: utils.NewRequestBuilder(),
+		createFormBuilder: func(body io.Writer) utils.FormBuilder {
+			return utils.NewFormBuilder(body)
+		},
 	}
 }
 
-func TestDecodeResponse(t *testing.T) {
-	stringInput := ""
+// NewOrgClient creates new OpenAI API client for specified Organization ID.
+//
+// Deprecated: Please use NewClientWithConfig.
+func NewOrgClient(authToken, org string) *Client {
+	config := DefaultConfig(authToken)
+	config.OrgID = org
+	return NewClientWithConfig(config)
+}
 
-	testCases := []struct {
-		name     string
-		value    interface{}
-		expected interface{}
-		body     io.Reader
-		hasError bool
-	}{
-		{
-			name:     "nil input",
-			value:    nil,
-			body:     bytes.NewReader([]byte("")),
-			expected: nil,
-		},
-		{
-			name:     "string input",
-			value:    &stringInput,
-			body:     bytes.NewReader([]byte("test")),
-			expected: "test",
-		},
-		{
-			name:  "map input",
-			value: &map[string]interface{}{},
-			body:  bytes.NewReader([]byte(`{"test": "test"}`)),
-			expected: map[string]interface{}{
-				"test": "test",
-			},
-		},
-		{
-			name:     "reader return error",
-			value:    &stringInput,
-			body:     &errorReader{err: errors.New("dummy")},
-			hasError: true,
-		},
-		{
-			name:  "audio text input",
-			value: &audioTextResponse{},
-			body:  bytes.NewReader([]byte("test")),
-			expected: audioTextResponse{
-				Text: "test",
-			},
-		},
+type requestOptions struct {
+	body   any
+	header http.Header
+}
+
+type requestOption func(*requestOptions)
+
+func withBody(body any) requestOption {
+	return func(args *requestOptions) {
+		args.body = body
+	}
+}
+
+func withContentType(contentType string) requestOption {
+	return func(args *requestOptions) {
+		args.header.Set("Content-Type", contentType)
+	}
+}
+
+func withBetaAssistantV1() requestOption {
+	return func(args *requestOptions) {
+		args.header.Set("OpenAI-Beta", "assistants=v1")
+	}
+}
+
+func (c *Client) newRequest(ctx context.Context, method, url string, setters ...requestOption) (*http.Request, error) {
+	// Default Options
+	args := &requestOptions{
+		body:   nil,
+		header: make(http.Header),
+	}
+	for _, setter := range setters {
+		setter(args)
+	}
+	req, err := c.requestBuilder.Build(ctx, method, url, args.body, args.header)
+	if err != nil {
+		return nil, err
+	}
+	c.setCommonHeaders(req)
+	return req, nil
+}
+
+func (c *Client) sendRequest(req *http.Request, v Response) error {
+	req.Header.Set("Accept", "application/json; charset=utf-8")
+
+	// Check whether Content-Type is already set, Upload Files API requires
+	// Content-Type == multipart/form-data
+	contentType := req.Header.Get("Content-Type")
+	if contentType == "" {
+		req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	}
 
-	assertEqual := func(t *testing.T, expected, actual interface{}) {
-		t.Helper()
-		if expected == actual {
-			return
+	res, err := c.config.HTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer res.Body.Close()
+
+	if isFailureStatusCode(res) {
+		return c.handleErrorResp(res)
+	}
+
+	if v != nil {
+		v.SetHeader(res.Header)
+	}
+
+	return decodeResponse(res.Body, v)
+}
+
+func (c *Client) sendRequestRaw(req *http.Request) (body io.ReadCloser, err error) {
+	resp, err := c.config.HTTPClient.Do(req)
+	if err != nil {
+		return
+	}
+
+	if isFailureStatusCode(resp) {
+		err = c.handleErrorResp(resp)
+		return
+	}
+	return resp.Body, nil
+}
+
+func sendRequestStream[T streamable](client *Client, req *http.Request) (*streamReader[T], error) {
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("Cache-Control", "no-cache")
+	req.Header.Set("Connection", "keep-alive")
+
+	resp, err := client.config.HTTPClient.Do(req) //nolint:bodyclose // body is closed in stream.Close()
+	if err != nil {
+		return new(streamReader[T]), err
+	}
+	if isFailureStatusCode(resp) {
+		return new(streamReader[T]), client.handleErrorResp(resp)
+	}
+	return &streamReader[T]{
+		emptyMessagesLimit: client.config.EmptyMessagesLimit,
+		reader:             bufio.NewReader(resp.Body),
+		response:           resp,
+		errAccumulator:     utils.NewErrorAccumulator(),
+		unmarshaler:        &utils.JSONUnmarshaler{},
+		httpHeader:         httpHeader(resp.Header),
+	}, nil
+}
+
+func (c *Client) setCommonHeaders(req *http.Request) {
+	// https://learn.microsoft.com/en-us/azure/cognitive-services/openai/reference#authentication
+	// Azure API Key authentication
+	if c.config.APIType == APITypeAzure {
+		req.Header.Set(AzureAPIKeyHeader, c.config.authToken)
+	} else {
+		// OpenAI or Azure AD authentication
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.config.authToken))
+	}
+	if c.config.OrgID != "" {
+		req.Header.Set("OpenAI-Organization", c.config.OrgID)
+	}
+}
+
+func isFailureStatusCode(resp *http.Response) bool {
+	return resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusBadRequest
+}
+
+func decodeResponse(body io.Reader, v any) error {
+	if v == nil {
+		return nil
+	}
+
+	switch o := v.(type) {
+	case *string:
+		return decodeString(body, o)
+	case *audioTextResponse:
+		return decodeString(body, &o.Text)
+	default:
+		return json.NewDecoder(body).Decode(v)
+	}
+}
+
+func decodeString(body io.Reader, output *string) error {
+	b, err := io.ReadAll(body)
+	if err != nil {
+		return err
+	}
+	*output = string(b)
+	return nil
+}
+
+// fullURL returns full URL for request.
+// args[0] is model name, if API type is Azure, model name is required to get deployment name.
+func (c *Client) fullURL(suffix string, args ...any) string {
+	// /openai/deployments/{model}/chat/completions?api-version={api_version}
+	if c.config.APIType == APITypeAzure || c.config.APIType == APITypeAzureAD {
+		baseURL := c.config.BaseURL
+		baseURL = strings.TrimRight(baseURL, "/")
+		// if suffix is /models change to {endpoint}/openai/models?api-version=2022-12-01
+		// https://learn.microsoft.com/en-us/rest/api/cognitiveservices/azureopenaistable/models/list?tabs=HTTP
+		if strings.Contains(suffix, "/models") {
+			return fmt.Sprintf("%s/%s%s?api-version=%s", baseURL, azureAPIPrefix, suffix, c.config.APIVersion)
 		}
-		v := reflect.ValueOf(actual).Elem().Interface()
-		if !reflect.DeepEqual(v, expected) {
-			t.Fatalf("Unexpected value: %v, expected: %v", v, expected)
+		azureDeploymentName := "UNKNOWN"
+		if len(args) > 0 {
+			model, ok := args[0].(string)
+			if ok {
+				azureDeploymentName = c.config.GetAzureDeploymentByModel(model)
+			}
 		}
+		return fmt.Sprintf("%s/%s/%s/%s%s?api-version=%s",
+			baseURL, azureAPIPrefix, azureDeploymentsPrefix,
+			azureDeploymentName, suffix, c.config.APIVersion,
+		)
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			err := decodeResponse(tc.body, tc.value)
-			if tc.hasError {
-				checks.HasError(t, err, "Unexpected nil error")
-				return
-			}
-			if err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
-			assertEqual(t, tc.expected, tc.value)
-		})
-	}
+	// c.config.APIType == APITypeOpenAI || c.config.APIType == ""
+	return fmt.Sprintf("%s%s", c.config.BaseURL, suffix)
 }
 
-type errorReader struct {
-	err error
-}
+func (c *Client) handleErrorResp(resp *http.Response) error {
+	contentType := resp.Header.Get("Content-Type")
+	mainContentType := strings.Split(contentType, ";")[0]
+	mainContentType = strings.ToLower(strings.TrimSpace(mainContentType))
 
-func (e *errorReader) Read(_ []byte) (n int, err error) {
-	return 0, e.err
-}
-
-func TestHandleErrorResp(t *testing.T) {
-	// var errRes *ErrorResponse
-	var errRes ErrorResponse
-	var reqErr RequestError
-	t.Log(errRes, errRes.Error)
-	if errRes.Error != nil {
-		reqErr.Err = errRes.Error
-	}
-	t.Log(fmt.Errorf("error, %w", &reqErr))
-	t.Log(errRes.Error, "nil pointer check Pass")
-
-	const mockToken = "mock token"
-	client := NewClient(mockToken)
-
-	testCases := []struct {
-		name     string
-		httpCode int
-		body     io.Reader
-		expected string
-	}{
-		{
-			name:     "401 Invalid Authentication",
-			httpCode: http.StatusUnauthorized,
-			body: bytes.NewReader([]byte(
-				`{
-					"error":{
-						"message":"You didn't provide an API key. ....",
-						"type":"invalid_request_error",
-						"param":null,
-						"code":null
-					}
-				}`,
-			)),
-			expected: "error, status code: 401, message: You didn't provide an API key. ....",
-		},
-		{
-			name:     "401 Azure Access Denied",
-			httpCode: http.StatusUnauthorized,
-			body: bytes.NewReader([]byte(
-				`{
-					"error":{
-						"code":"AccessDenied",
-						"message":"Access denied due to Virtual Network/Firewall rules."
-					}
-				}`,
-			)),
-			expected: "error, status code: 401, message: Access denied due to Virtual Network/Firewall rules.",
-		},
-		{
-			name:     "503 Model Overloaded",
-			httpCode: http.StatusServiceUnavailable,
-			body: bytes.NewReader([]byte(`
-				{
-					"error":{
-						"message":"That model...",
-						"type":"server_error",
-						"param":null,
-						"code":null
-					}
-				}`)),
-			expected: "error, status code: 503, message: That model...",
-		},
-		{
-			name:     "503 no message (Unknown response)",
-			httpCode: http.StatusServiceUnavailable,
-			body: bytes.NewReader([]byte(`
-				{
-					"error":{}
-				}`)),
-			expected: "error, status code: 503, message: ",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			testCase := &http.Response{}
-			testCase.StatusCode = tc.httpCode
-			testCase.Body = io.NopCloser(tc.body)
-			err := client.handleErrorResp(testCase)
-			t.Log(err.Error())
-			if err.Error() != tc.expected {
-				t.Errorf("Unexpected error: %v , expected: %s", err, tc.expected)
-				t.Fail()
+	switch mainContentType {
+	case "application/json":
+		var errRes ErrorResponse
+		err := json.NewDecoder(resp.Body).Decode(&errRes)
+		if err != nil || errRes.Error == nil {
+			reqErr := &RequestError{
+				HTTPStatusCode: resp.StatusCode,
+				Err:            err,
 			}
-
-			e := &APIError{}
-			if !errors.As(err, &e) {
-				t.Errorf("(%s) Expected error to be of type APIError", tc.name)
-				t.Fail()
+			if errRes.Error != nil {
+				reqErr.Err = errRes.Error
 			}
-		})
-	}
-}
-
-func TestClientReturnsRequestBuilderErrors(t *testing.T) {
-	config := DefaultConfig(test.GetTestToken())
-	client := NewClientWithConfig(config)
-	client.requestBuilder = &failingRequestBuilder{}
-	ctx := context.Background()
-
-	type TestCase struct {
-		Name     string
-		TestFunc func() (any, error)
-	}
-
-	testCases := []TestCase{
-		{"CreateCompletion", func() (any, error) {
-			return client.CreateCompletion(ctx, CompletionRequest{Prompt: "testing"})
-		}},
-		{"CreateCompletionStream", func() (any, error) {
-			return client.CreateCompletionStream(ctx, CompletionRequest{Prompt: ""})
-		}},
-		{"CreateChatCompletion", func() (any, error) {
-			return client.CreateChatCompletion(ctx, ChatCompletionRequest{Model: GPT3Dot5Turbo})
-		}},
-		{"CreateChatCompletionStream", func() (any, error) {
-			return client.CreateChatCompletionStream(ctx, ChatCompletionRequest{Model: GPT3Dot5Turbo})
-		}},
-		{"CreateFineTune", func() (any, error) {
-			return client.CreateFineTune(ctx, FineTuneRequest{})
-		}},
-		{"ListFineTunes", func() (any, error) {
-			return client.ListFineTunes(ctx)
-		}},
-		{"CancelFineTune", func() (any, error) {
-			return client.CancelFineTune(ctx, "")
-		}},
-		{"GetFineTune", func() (any, error) {
-			return client.GetFineTune(ctx, "")
-		}},
-		{"DeleteFineTune", func() (any, error) {
-			return client.DeleteFineTune(ctx, "")
-		}},
-		{"ListFineTuneEvents", func() (any, error) {
-			return client.ListFineTuneEvents(ctx, "")
-		}},
-		{"CreateFineTuningJob", func() (any, error) {
-			return client.CreateFineTuningJob(ctx, FineTuningJobRequest{})
-		}},
-		{"CancelFineTuningJob", func() (any, error) {
-			return client.CancelFineTuningJob(ctx, "")
-		}},
-		{"RetrieveFineTuningJob", func() (any, error) {
-			return client.RetrieveFineTuningJob(ctx, "")
-		}},
-		{"ListFineTuningJobEvents", func() (any, error) {
-			return client.ListFineTuningJobEvents(ctx, "")
-		}},
-		{"Moderations", func() (any, error) {
-			return client.Moderations(ctx, ModerationRequest{})
-		}},
-		{"Edits", func() (any, error) {
-			return client.Edits(ctx, EditsRequest{})
-		}},
-		{"CreateEmbeddings", func() (any, error) {
-			return client.CreateEmbeddings(ctx, EmbeddingRequest{})
-		}},
-		{"CreateImage", func() (any, error) {
-			return client.CreateImage(ctx, ImageRequest{})
-		}},
-		{"CreateFileBytes", func() (any, error) {
-			return client.CreateFileBytes(ctx, FileBytesRequest{})
-		}},
-		{"DeleteFile", func() (any, error) {
-			return nil, client.DeleteFile(ctx, "")
-		}},
-		{"GetFile", func() (any, error) {
-			return client.GetFile(ctx, "")
-		}},
-		{"GetFileContent", func() (any, error) {
-			return client.GetFileContent(ctx, "")
-		}},
-		{"ListFiles", func() (any, error) {
-			return client.ListFiles(ctx)
-		}},
-		{"ListEngines", func() (any, error) {
-			return client.ListEngines(ctx)
-		}},
-		{"GetEngine", func() (any, error) {
-			return client.GetEngine(ctx, "")
-		}},
-		{"ListModels", func() (any, error) {
-			return client.ListModels(ctx)
-		}},
-		{"GetModel", func() (any, error) {
-			return client.GetModel(ctx, "text-davinci-003")
-		}},
-		{"DeleteFineTuneModel", func() (any, error) {
-			return client.DeleteFineTuneModel(ctx, "")
-		}},
-		{"CreateAssistant", func() (any, error) {
-			return client.CreateAssistant(ctx, AssistantRequest{})
-		}},
-		{"RetrieveAssistant", func() (any, error) {
-			return client.RetrieveAssistant(ctx, "")
-		}},
-		{"ModifyAssistant", func() (any, error) {
-			return client.ModifyAssistant(ctx, "", AssistantRequest{})
-		}},
-		{"DeleteAssistant", func() (any, error) {
-			return client.DeleteAssistant(ctx, "")
-		}},
-		{"ListAssistants", func() (any, error) {
-			return client.ListAssistants(ctx, nil, nil, nil, nil)
-		}},
-		{"CreateAssistantFile", func() (any, error) {
-			return client.CreateAssistantFile(ctx, "", AssistantFileRequest{})
-		}},
-		{"ListAssistantFiles", func() (any, error) {
-			return client.ListAssistantFiles(ctx, "", nil, nil, nil, nil)
-		}},
-		{"RetrieveAssistantFile", func() (any, error) {
-			return client.RetrieveAssistantFile(ctx, "", "")
-		}},
-		{"DeleteAssistantFile", func() (any, error) {
-			return nil, client.DeleteAssistantFile(ctx, "", "")
-		}},
-		{"CreateMessage", func() (any, error) {
-			return client.CreateMessage(ctx, "", MessageRequest{})
-		}},
-		{"ListMessage", func() (any, error) {
-			return client.ListMessage(ctx, "", nil, nil, nil, nil)
-		}},
-		{"RetrieveMessage", func() (any, error) {
-			return client.RetrieveMessage(ctx, "", "")
-		}},
-		{"ModifyMessage", func() (any, error) {
-			return client.ModifyMessage(ctx, "", "", nil)
-		}},
-		{"RetrieveMessageFile", func() (any, error) {
-			return client.RetrieveMessageFile(ctx, "", "", "")
-		}},
-		{"ListMessageFiles", func() (any, error) {
-			return client.ListMessageFiles(ctx, "", "")
-		}},
-		{"CreateThread", func() (any, error) {
-			return client.CreateThread(ctx, ThreadRequest{})
-		}},
-		{"RetrieveThread", func() (any, error) {
-			return client.RetrieveThread(ctx, "")
-		}},
-		{"ModifyThread", func() (any, error) {
-			return client.ModifyThread(ctx, "", ModifyThreadRequest{})
-		}},
-		{"DeleteThread", func() (any, error) {
-			return client.DeleteThread(ctx, "")
-		}},
-		{"CreateRun", func() (any, error) {
-			return client.CreateRun(ctx, "", RunRequest{})
-		}},
-		{"RetrieveRun", func() (any, error) {
-			return client.RetrieveRun(ctx, "", "")
-		}},
-		{"ModifyRun", func() (any, error) {
-			return client.ModifyRun(ctx, "", "", RunModifyRequest{})
-		}},
-		{"ListRuns", func() (any, error) {
-			return client.ListRuns(ctx, "", Pagination{})
-		}},
-		{"SubmitToolOutputs", func() (any, error) {
-			return client.SubmitToolOutputs(ctx, "", "", SubmitToolOutputsRequest{})
-		}},
-		{"CancelRun", func() (any, error) {
-			return client.CancelRun(ctx, "", "")
-		}},
-		{"CreateThreadAndRun", func() (any, error) {
-			return client.CreateThreadAndRun(ctx, CreateThreadAndRunRequest{})
-		}},
-		{"RetrieveRunStep", func() (any, error) {
-			return client.RetrieveRunStep(ctx, "", "", "")
-		}},
-		{"ListRunSteps", func() (any, error) {
-			return client.ListRunSteps(ctx, "", "", Pagination{})
-		}},
-		{"CreateSpeech", func() (any, error) {
-			return client.CreateSpeech(ctx, CreateSpeechRequest{Model: TTSModel1, Voice: VoiceAlloy})
-		}},
-	}
-
-	for _, testCase := range testCases {
-		_, err := testCase.TestFunc()
-		if !errors.Is(err, errTestRequestBuilderFailed) {
-			t.Fatalf("%s did not return error when request builder failed: %v", testCase.Name, err)
+			return reqErr
 		}
-	}
-}
 
-func TestClientReturnsRequestBuilderErrorsAddtion(t *testing.T) {
-	config := DefaultConfig(test.GetTestToken())
-	client := NewClientWithConfig(config)
-	client.requestBuilder = &failingRequestBuilder{}
-	ctx := context.Background()
-	_, err := client.CreateCompletion(ctx, CompletionRequest{Prompt: 1})
-	if !errors.Is(err, ErrCompletionRequestPromptTypeNotSupported) {
-		t.Fatalf("Did not return error when request builder failed: %v", err)
-	}
-	_, err = client.CreateCompletionStream(ctx, CompletionRequest{Prompt: 1})
-	if !errors.Is(err, ErrCompletionRequestPromptTypeNotSupported) {
-		t.Fatalf("Did not return error when request builder failed: %v", err)
+		errRes.Error.HTTPStatusCode = resp.StatusCode
+		return errRes.Error
+	case "text/plain":
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+
+		return &RequestError{
+			HTTPStatusCode: resp.StatusCode,
+			Err:            fmt.Errorf("%s", body),
+		}
+	default:
+		return &RequestError{
+			HTTPStatusCode: resp.StatusCode,
+			Err:            fmt.Errorf("unexpected content type: %s", contentType),
+		}
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -133,16 +133,14 @@ func TestHandleJSONErrorResp(t *testing.T) {
 	client := NewClient(mockToken)
 
 	testCases := []struct {
-		name        string
-		httpCode    int
-		contentType string
-		body        io.Reader
-		expected    string
+		name     string
+		httpCode int
+		body     io.Reader
+		expected string
 	}{
 		{
-			name:        "401 Invalid Authentication",
-			httpCode:    http.StatusUnauthorized,
-			contentType: "application/json",
+			name:     "401 Invalid Authentication",
+			httpCode: http.StatusUnauthorized,
 			body: bytes.NewReader([]byte(
 				`{
 					"error":{
@@ -156,9 +154,8 @@ func TestHandleJSONErrorResp(t *testing.T) {
 			expected: "error, status code: 401, message: You didn't provide an API key. ....",
 		},
 		{
-			name:        "401 Azure Access Denied",
-			httpCode:    http.StatusUnauthorized,
-			contentType: "application/json",
+			name:     "401 Azure Access Denied",
+			httpCode: http.StatusUnauthorized,
 			body: bytes.NewReader([]byte(
 				`{
 					"error":{
@@ -170,9 +167,8 @@ func TestHandleJSONErrorResp(t *testing.T) {
 			expected: "error, status code: 401, message: Access denied due to Virtual Network/Firewall rules.",
 		},
 		{
-			name:        "503 Model Overloaded",
-			httpCode:    http.StatusServiceUnavailable,
-			contentType: "application/json",
+			name:     "503 Model Overloaded",
+			httpCode: http.StatusServiceUnavailable,
 			body: bytes.NewReader([]byte(`
 				{
 					"error":{
@@ -185,9 +181,8 @@ func TestHandleJSONErrorResp(t *testing.T) {
 			expected: "error, status code: 503, message: That model...",
 		},
 		{
-			name:        "503 no message (Unknown response)",
-			httpCode:    http.StatusServiceUnavailable,
-			contentType: "application/json",
+			name:     "503 no message (Unknown response)",
+			httpCode: http.StatusServiceUnavailable,
 			body: bytes.NewReader([]byte(`
 				{
 					"error":{}
@@ -201,7 +196,6 @@ func TestHandleJSONErrorResp(t *testing.T) {
 			testCase := &http.Response{}
 			testCase.StatusCode = tc.httpCode
 			testCase.Header = http.Header{}
-			testCase.Header.Set("Content-Type", tc.contentType)
 			testCase.Body = io.NopCloser(tc.body)
 			err := client.handleErrorResp(testCase)
 			t.Log(err.Error())

--- a/client_test.go
+++ b/client_test.go
@@ -1,283 +1,486 @@
-package openai
+package openai //nolint:testpackage // testing private field
 
 import (
-	"bufio"
+	"bytes"
 	"context"
-	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
+	"reflect"
+	"testing"
 
-	utils "github.com/odannyc/go-openai/internal"
+	"github.com/odannyc/go-openai/internal/test"
+	"github.com/odannyc/go-openai/internal/test/checks"
 )
 
-// Client is OpenAI GPT-3 API client.
-type Client struct {
-	config ClientConfig
+var errTestRequestBuilderFailed = errors.New("test request builder failed")
 
-	requestBuilder    utils.RequestBuilder
-	createFormBuilder func(io.Writer) utils.FormBuilder
+type failingRequestBuilder struct{}
+
+func (*failingRequestBuilder) Build(_ context.Context, _, _ string, _ any, _ http.Header) (*http.Request, error) {
+	return nil, errTestRequestBuilderFailed
 }
 
-type Response interface {
-	SetHeader(http.Header)
+func TestClient(t *testing.T) {
+	const mockToken = "mock token"
+	client := NewClient(mockToken)
+	if client.config.authToken != mockToken {
+		t.Errorf("Client does not contain proper token")
+	}
+
+	const mockOrg = "mock org"
+	client = NewOrgClient(mockToken, mockOrg)
+	if client.config.authToken != mockToken {
+		t.Errorf("Client does not contain proper token")
+	}
+	if client.config.OrgID != mockOrg {
+		t.Errorf("Client does not contain proper orgID")
+	}
 }
 
-type httpHeader http.Header
+func TestDecodeResponse(t *testing.T) {
+	stringInput := ""
 
-func (h *httpHeader) SetHeader(header http.Header) {
-	*h = httpHeader(header)
-}
-
-func (h *httpHeader) Header() http.Header {
-	return http.Header(*h)
-}
-
-func (h *httpHeader) GetRateLimitHeaders() RateLimitHeaders {
-	return newRateLimitHeaders(h.Header())
-}
-
-// NewClient creates new OpenAI API client.
-func NewClient(authToken string) *Client {
-	config := DefaultConfig(authToken)
-	return NewClientWithConfig(config)
-}
-
-// NewClientWithConfig creates new OpenAI API client for specified config.
-func NewClientWithConfig(config ClientConfig) *Client {
-	return &Client{
-		config:         config,
-		requestBuilder: utils.NewRequestBuilder(),
-		createFormBuilder: func(body io.Writer) utils.FormBuilder {
-			return utils.NewFormBuilder(body)
+	testCases := []struct {
+		name     string
+		value    interface{}
+		expected interface{}
+		body     io.Reader
+		hasError bool
+	}{
+		{
+			name:     "nil input",
+			value:    nil,
+			body:     bytes.NewReader([]byte("")),
+			expected: nil,
+		},
+		{
+			name:     "string input",
+			value:    &stringInput,
+			body:     bytes.NewReader([]byte("test")),
+			expected: "test",
+		},
+		{
+			name:  "map input",
+			value: &map[string]interface{}{},
+			body:  bytes.NewReader([]byte(`{"test": "test"}`)),
+			expected: map[string]interface{}{
+				"test": "test",
+			},
+		},
+		{
+			name:     "reader return error",
+			value:    &stringInput,
+			body:     &errorReader{err: errors.New("dummy")},
+			hasError: true,
+		},
+		{
+			name:  "audio text input",
+			value: &audioTextResponse{},
+			body:  bytes.NewReader([]byte("test")),
+			expected: audioTextResponse{
+				Text: "test",
+			},
 		},
 	}
-}
 
-// NewOrgClient creates new OpenAI API client for specified Organization ID.
-//
-// Deprecated: Please use NewClientWithConfig.
-func NewOrgClient(authToken, org string) *Client {
-	config := DefaultConfig(authToken)
-	config.OrgID = org
-	return NewClientWithConfig(config)
-}
-
-type requestOptions struct {
-	body   any
-	header http.Header
-}
-
-type requestOption func(*requestOptions)
-
-func withBody(body any) requestOption {
-	return func(args *requestOptions) {
-		args.body = body
-	}
-}
-
-func withContentType(contentType string) requestOption {
-	return func(args *requestOptions) {
-		args.header.Set("Content-Type", contentType)
-	}
-}
-
-func withBetaAssistantV1() requestOption {
-	return func(args *requestOptions) {
-		args.header.Set("OpenAI-Beta", "assistants=v1")
-	}
-}
-
-func (c *Client) newRequest(ctx context.Context, method, url string, setters ...requestOption) (*http.Request, error) {
-	// Default Options
-	args := &requestOptions{
-		body:   nil,
-		header: make(http.Header),
-	}
-	for _, setter := range setters {
-		setter(args)
-	}
-	req, err := c.requestBuilder.Build(ctx, method, url, args.body, args.header)
-	if err != nil {
-		return nil, err
-	}
-	c.setCommonHeaders(req)
-	return req, nil
-}
-
-func (c *Client) sendRequest(req *http.Request, v Response) error {
-	req.Header.Set("Accept", "application/json; charset=utf-8")
-
-	// Check whether Content-Type is already set, Upload Files API requires
-	// Content-Type == multipart/form-data
-	contentType := req.Header.Get("Content-Type")
-	if contentType == "" {
-		req.Header.Set("Content-Type", "application/json; charset=utf-8")
-	}
-
-	res, err := c.config.HTTPClient.Do(req)
-	if err != nil {
-		return err
-	}
-
-	defer res.Body.Close()
-
-	if isFailureStatusCode(res) {
-		return c.handleErrorResp(res)
-	}
-
-	if v != nil {
-		v.SetHeader(res.Header)
-	}
-
-	return decodeResponse(res.Body, v)
-}
-
-func (c *Client) sendRequestRaw(req *http.Request) (body io.ReadCloser, err error) {
-	resp, err := c.config.HTTPClient.Do(req)
-	if err != nil {
-		return
-	}
-
-	if isFailureStatusCode(resp) {
-		err = c.handleErrorResp(resp)
-		return
-	}
-	return resp.Body, nil
-}
-
-func sendRequestStream[T streamable](client *Client, req *http.Request) (*streamReader[T], error) {
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "text/event-stream")
-	req.Header.Set("Cache-Control", "no-cache")
-	req.Header.Set("Connection", "keep-alive")
-
-	resp, err := client.config.HTTPClient.Do(req) //nolint:bodyclose // body is closed in stream.Close()
-	if err != nil {
-		return new(streamReader[T]), err
-	}
-	if isFailureStatusCode(resp) {
-		return new(streamReader[T]), client.handleErrorResp(resp)
-	}
-	return &streamReader[T]{
-		emptyMessagesLimit: client.config.EmptyMessagesLimit,
-		reader:             bufio.NewReader(resp.Body),
-		response:           resp,
-		errAccumulator:     utils.NewErrorAccumulator(),
-		unmarshaler:        &utils.JSONUnmarshaler{},
-		httpHeader:         httpHeader(resp.Header),
-	}, nil
-}
-
-func (c *Client) setCommonHeaders(req *http.Request) {
-	// https://learn.microsoft.com/en-us/azure/cognitive-services/openai/reference#authentication
-	// Azure API Key authentication
-	if c.config.APIType == APITypeAzure {
-		req.Header.Set(AzureAPIKeyHeader, c.config.authToken)
-	} else {
-		// OpenAI or Azure AD authentication
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.config.authToken))
-	}
-	if c.config.OrgID != "" {
-		req.Header.Set("OpenAI-Organization", c.config.OrgID)
-	}
-}
-
-func isFailureStatusCode(resp *http.Response) bool {
-	return resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusBadRequest
-}
-
-func decodeResponse(body io.Reader, v any) error {
-	if v == nil {
-		return nil
-	}
-
-	switch o := v.(type) {
-	case *string:
-		return decodeString(body, o)
-	case *audioTextResponse:
-		return decodeString(body, &o.Text)
-	default:
-		return json.NewDecoder(body).Decode(v)
-	}
-}
-
-func decodeString(body io.Reader, output *string) error {
-	b, err := io.ReadAll(body)
-	if err != nil {
-		return err
-	}
-	*output = string(b)
-	return nil
-}
-
-// fullURL returns full URL for request.
-// args[0] is model name, if API type is Azure, model name is required to get deployment name.
-func (c *Client) fullURL(suffix string, args ...any) string {
-	// /openai/deployments/{model}/chat/completions?api-version={api_version}
-	if c.config.APIType == APITypeAzure || c.config.APIType == APITypeAzureAD {
-		baseURL := c.config.BaseURL
-		baseURL = strings.TrimRight(baseURL, "/")
-		// if suffix is /models change to {endpoint}/openai/models?api-version=2022-12-01
-		// https://learn.microsoft.com/en-us/rest/api/cognitiveservices/azureopenaistable/models/list?tabs=HTTP
-		if strings.Contains(suffix, "/models") {
-			return fmt.Sprintf("%s/%s%s?api-version=%s", baseURL, azureAPIPrefix, suffix, c.config.APIVersion)
+	assertEqual := func(t *testing.T, expected, actual interface{}) {
+		t.Helper()
+		if expected == actual {
+			return
 		}
-		azureDeploymentName := "UNKNOWN"
-		if len(args) > 0 {
-			model, ok := args[0].(string)
-			if ok {
-				azureDeploymentName = c.config.GetAzureDeploymentByModel(model)
+		v := reflect.ValueOf(actual).Elem().Interface()
+		if !reflect.DeepEqual(v, expected) {
+			t.Fatalf("Unexpected value: %v, expected: %v", v, expected)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := decodeResponse(tc.body, tc.value)
+			if tc.hasError {
+				checks.HasError(t, err, "Unexpected nil error")
+				return
 			}
-		}
-		return fmt.Sprintf("%s/%s/%s/%s%s?api-version=%s",
-			baseURL, azureAPIPrefix, azureDeploymentsPrefix,
-			azureDeploymentName, suffix, c.config.APIVersion,
-		)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			assertEqual(t, tc.expected, tc.value)
+		})
 	}
-
-	// c.config.APIType == APITypeOpenAI || c.config.APIType == ""
-	return fmt.Sprintf("%s%s", c.config.BaseURL, suffix)
 }
 
-func (c *Client) handleErrorResp(resp *http.Response) error {
-	contentType := resp.Header.Get("Content-Type")
-	mainContentType := strings.Split(contentType, ";")[0]
-	mainContentType = strings.ToLower(strings.TrimSpace(mainContentType))
+type errorReader struct {
+	err error
+}
 
-	switch mainContentType {
-	case "application/json":
-		var errRes ErrorResponse
-		err := json.NewDecoder(resp.Body).Decode(&errRes)
-		if err != nil || errRes.Error == nil {
-			reqErr := &RequestError{
-				HTTPStatusCode: resp.StatusCode,
-				Err:            err,
+func (e *errorReader) Read(_ []byte) (n int, err error) {
+	return 0, e.err
+}
+
+func TestHandleJSONErrorResp(t *testing.T) {
+	var errRes ErrorResponse
+	var reqErr RequestError
+	t.Log(errRes, errRes.Error)
+	if errRes.Error != nil {
+		reqErr.Err = errRes.Error
+	}
+	t.Log(fmt.Errorf("error, %w", &reqErr))
+	t.Log(errRes.Error, "nil pointer check Pass")
+
+	const mockToken = "mock token"
+	client := NewClient(mockToken)
+
+	testCases := []struct {
+		name        string
+		httpCode    int
+		contentType string
+		body        io.Reader
+		expected    string
+	}{
+		{
+			name:        "401 Invalid Authentication",
+			httpCode:    http.StatusUnauthorized,
+			contentType: "application/json",
+			body: bytes.NewReader([]byte(
+				`{
+					"error":{
+						"message":"You didn't provide an API key. ....",
+						"type":"invalid_request_error",
+						"param":null,
+						"code":null
+					}
+				}`,
+			)),
+			expected: "error, status code: 401, message: You didn't provide an API key. ....",
+		},
+		{
+			name:        "401 Azure Access Denied",
+			httpCode:    http.StatusUnauthorized,
+			contentType: "application/json",
+			body: bytes.NewReader([]byte(
+				`{
+					"error":{
+						"code":"AccessDenied",
+						"message":"Access denied due to Virtual Network/Firewall rules."
+					}
+				}`,
+			)),
+			expected: "error, status code: 401, message: Access denied due to Virtual Network/Firewall rules.",
+		},
+		{
+			name:        "503 Model Overloaded",
+			httpCode:    http.StatusServiceUnavailable,
+			contentType: "application/json",
+			body: bytes.NewReader([]byte(`
+				{
+					"error":{
+						"message":"That model...",
+						"type":"server_error",
+						"param":null,
+						"code":null
+					}
+				}`)),
+			expected: "error, status code: 503, message: That model...",
+		},
+		{
+			name:        "503 no message (Unknown response)",
+			httpCode:    http.StatusServiceUnavailable,
+			contentType: "application/json",
+			body: bytes.NewReader([]byte(`
+				{
+					"error":{}
+				}`)),
+			expected: "error, status code: 503, message: ",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testCase := &http.Response{}
+			testCase.StatusCode = tc.httpCode
+			testCase.Header = http.Header{}
+			testCase.Header.Set("Content-Type", tc.contentType)
+			testCase.Body = io.NopCloser(tc.body)
+			err := client.handleErrorResp(testCase)
+			t.Log(err.Error())
+			if err.Error() != tc.expected {
+				t.Errorf("Unexpected error: %v , expected: %s", err, tc.expected)
+				t.Fail()
 			}
-			if errRes.Error != nil {
-				reqErr.Err = errRes.Error
+
+			e := &APIError{}
+			if !errors.As(err, &e) {
+				t.Errorf("(%s) Expected error to be of type APIError", tc.name)
+				t.Fail()
 			}
-			return reqErr
-		}
+		})
+	}
+}
 
-		errRes.Error.HTTPStatusCode = resp.StatusCode
-		return errRes.Error
-	case "text/plain":
-		defer resp.Body.Close()
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return err
-		}
+func TestHandleTextErrorResp(t *testing.T) {
+	const mockToken = "mock token"
+	client := NewClient(mockToken)
 
-		return &RequestError{
-			HTTPStatusCode: resp.StatusCode,
-			Err:            fmt.Errorf("%s", body),
+	testCases := []struct {
+		name        string
+		httpCode    int
+		contentType string
+		body        io.Reader
+		expected    string
+	}{
+		{
+			name:        "401 Invalid Authentication",
+			httpCode:    http.StatusUnauthorized,
+			contentType: "text/plain",
+			body:        bytes.NewReader([]byte(`You didn't provide an API key. ....`)),
+			expected:    "error, status code: 401, message: You didn't provide an API key. ....",
+		},
+		{
+			name:        "401 Azure Access Denied",
+			httpCode:    http.StatusUnauthorized,
+			contentType: "text/plain",
+			body:        bytes.NewReader([]byte(`Access denied due to Virtual Network/Firewall rules.`)),
+			expected:    "error, status code: 401, message: Access denied due to Virtual Network/Firewall rules.",
+		},
+		{
+			name:        "503 Model Overloaded",
+			httpCode:    http.StatusServiceUnavailable,
+			contentType: "text/plain",
+			body:        bytes.NewReader([]byte(`That model...`)),
+			expected:    "error, status code: 503, message: That model...",
+		},
+		{
+			name:        "503 no message (Unknown response)",
+			httpCode:    http.StatusServiceUnavailable,
+			contentType: "text/plain",
+			body:        bytes.NewReader([]byte(``)),
+			expected:    "error, status code: 503, message: ",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testCase := &http.Response{}
+			testCase.StatusCode = tc.httpCode
+			testCase.Header = http.Header{}
+			testCase.Header.Set("Content-Type", tc.contentType)
+			testCase.Body = io.NopCloser(tc.body)
+			err := client.handleErrorResp(testCase)
+			t.Log(err.Error())
+			if err.Error() != tc.expected {
+				t.Errorf("Unexpected error: %v , expected: %s", err, tc.expected)
+				t.Fail()
+			}
+		})
+	}
+}
+
+func TestClientReturnsRequestBuilderErrors(t *testing.T) {
+	config := DefaultConfig(test.GetTestToken())
+	client := NewClientWithConfig(config)
+	client.requestBuilder = &failingRequestBuilder{}
+	ctx := context.Background()
+
+	type TestCase struct {
+		Name     string
+		TestFunc func() (any, error)
+	}
+
+	testCases := []TestCase{
+		{"CreateCompletion", func() (any, error) {
+			return client.CreateCompletion(ctx, CompletionRequest{Prompt: "testing"})
+		}},
+		{"CreateCompletionStream", func() (any, error) {
+			return client.CreateCompletionStream(ctx, CompletionRequest{Prompt: ""})
+		}},
+		{"CreateChatCompletion", func() (any, error) {
+			return client.CreateChatCompletion(ctx, ChatCompletionRequest{Model: GPT3Dot5Turbo})
+		}},
+		{"CreateChatCompletionStream", func() (any, error) {
+			return client.CreateChatCompletionStream(ctx, ChatCompletionRequest{Model: GPT3Dot5Turbo})
+		}},
+		{"CreateFineTune", func() (any, error) {
+			return client.CreateFineTune(ctx, FineTuneRequest{})
+		}},
+		{"ListFineTunes", func() (any, error) {
+			return client.ListFineTunes(ctx)
+		}},
+		{"CancelFineTune", func() (any, error) {
+			return client.CancelFineTune(ctx, "")
+		}},
+		{"GetFineTune", func() (any, error) {
+			return client.GetFineTune(ctx, "")
+		}},
+		{"DeleteFineTune", func() (any, error) {
+			return client.DeleteFineTune(ctx, "")
+		}},
+		{"ListFineTuneEvents", func() (any, error) {
+			return client.ListFineTuneEvents(ctx, "")
+		}},
+		{"CreateFineTuningJob", func() (any, error) {
+			return client.CreateFineTuningJob(ctx, FineTuningJobRequest{})
+		}},
+		{"CancelFineTuningJob", func() (any, error) {
+			return client.CancelFineTuningJob(ctx, "")
+		}},
+		{"RetrieveFineTuningJob", func() (any, error) {
+			return client.RetrieveFineTuningJob(ctx, "")
+		}},
+		{"ListFineTuningJobEvents", func() (any, error) {
+			return client.ListFineTuningJobEvents(ctx, "")
+		}},
+		{"Moderations", func() (any, error) {
+			return client.Moderations(ctx, ModerationRequest{})
+		}},
+		{"Edits", func() (any, error) {
+			return client.Edits(ctx, EditsRequest{})
+		}},
+		{"CreateEmbeddings", func() (any, error) {
+			return client.CreateEmbeddings(ctx, EmbeddingRequest{})
+		}},
+		{"CreateImage", func() (any, error) {
+			return client.CreateImage(ctx, ImageRequest{})
+		}},
+		{"CreateFileBytes", func() (any, error) {
+			return client.CreateFileBytes(ctx, FileBytesRequest{})
+		}},
+		{"DeleteFile", func() (any, error) {
+			return nil, client.DeleteFile(ctx, "")
+		}},
+		{"GetFile", func() (any, error) {
+			return client.GetFile(ctx, "")
+		}},
+		{"GetFileContent", func() (any, error) {
+			return client.GetFileContent(ctx, "")
+		}},
+		{"ListFiles", func() (any, error) {
+			return client.ListFiles(ctx)
+		}},
+		{"ListEngines", func() (any, error) {
+			return client.ListEngines(ctx)
+		}},
+		{"GetEngine", func() (any, error) {
+			return client.GetEngine(ctx, "")
+		}},
+		{"ListModels", func() (any, error) {
+			return client.ListModels(ctx)
+		}},
+		{"GetModel", func() (any, error) {
+			return client.GetModel(ctx, "text-davinci-003")
+		}},
+		{"DeleteFineTuneModel", func() (any, error) {
+			return client.DeleteFineTuneModel(ctx, "")
+		}},
+		{"CreateAssistant", func() (any, error) {
+			return client.CreateAssistant(ctx, AssistantRequest{})
+		}},
+		{"RetrieveAssistant", func() (any, error) {
+			return client.RetrieveAssistant(ctx, "")
+		}},
+		{"ModifyAssistant", func() (any, error) {
+			return client.ModifyAssistant(ctx, "", AssistantRequest{})
+		}},
+		{"DeleteAssistant", func() (any, error) {
+			return client.DeleteAssistant(ctx, "")
+		}},
+		{"ListAssistants", func() (any, error) {
+			return client.ListAssistants(ctx, nil, nil, nil, nil)
+		}},
+		{"CreateAssistantFile", func() (any, error) {
+			return client.CreateAssistantFile(ctx, "", AssistantFileRequest{})
+		}},
+		{"ListAssistantFiles", func() (any, error) {
+			return client.ListAssistantFiles(ctx, "", nil, nil, nil, nil)
+		}},
+		{"RetrieveAssistantFile", func() (any, error) {
+			return client.RetrieveAssistantFile(ctx, "", "")
+		}},
+		{"DeleteAssistantFile", func() (any, error) {
+			return nil, client.DeleteAssistantFile(ctx, "", "")
+		}},
+		{"CreateMessage", func() (any, error) {
+			return client.CreateMessage(ctx, "", MessageRequest{})
+		}},
+		{"ListMessage", func() (any, error) {
+			return client.ListMessage(ctx, "", nil, nil, nil, nil)
+		}},
+		{"RetrieveMessage", func() (any, error) {
+			return client.RetrieveMessage(ctx, "", "")
+		}},
+		{"ModifyMessage", func() (any, error) {
+			return client.ModifyMessage(ctx, "", "", nil)
+		}},
+		{"RetrieveMessageFile", func() (any, error) {
+			return client.RetrieveMessageFile(ctx, "", "", "")
+		}},
+		{"ListMessageFiles", func() (any, error) {
+			return client.ListMessageFiles(ctx, "", "")
+		}},
+		{"CreateThread", func() (any, error) {
+			return client.CreateThread(ctx, ThreadRequest{})
+		}},
+		{"RetrieveThread", func() (any, error) {
+			return client.RetrieveThread(ctx, "")
+		}},
+		{"ModifyThread", func() (any, error) {
+			return client.ModifyThread(ctx, "", ModifyThreadRequest{})
+		}},
+		{"DeleteThread", func() (any, error) {
+			return client.DeleteThread(ctx, "")
+		}},
+		{"CreateRun", func() (any, error) {
+			return client.CreateRun(ctx, "", RunRequest{})
+		}},
+		{"RetrieveRun", func() (any, error) {
+			return client.RetrieveRun(ctx, "", "")
+		}},
+		{"ModifyRun", func() (any, error) {
+			return client.ModifyRun(ctx, "", "", RunModifyRequest{})
+		}},
+		{"ListRuns", func() (any, error) {
+			return client.ListRuns(ctx, "", Pagination{})
+		}},
+		{"SubmitToolOutputs", func() (any, error) {
+			return client.SubmitToolOutputs(ctx, "", "", SubmitToolOutputsRequest{})
+		}},
+		{"CancelRun", func() (any, error) {
+			return client.CancelRun(ctx, "", "")
+		}},
+		{"CreateThreadAndRun", func() (any, error) {
+			return client.CreateThreadAndRun(ctx, CreateThreadAndRunRequest{})
+		}},
+		{"RetrieveRunStep", func() (any, error) {
+			return client.RetrieveRunStep(ctx, "", "", "")
+		}},
+		{"ListRunSteps", func() (any, error) {
+			return client.ListRunSteps(ctx, "", "", Pagination{})
+		}},
+		{"CreateSpeech", func() (any, error) {
+			return client.CreateSpeech(ctx, CreateSpeechRequest{Model: TTSModel1, Voice: VoiceAlloy})
+		}},
+	}
+
+	for _, testCase := range testCases {
+		_, err := testCase.TestFunc()
+		if !errors.Is(err, errTestRequestBuilderFailed) {
+			t.Fatalf("%s did not return error when request builder failed: %v", testCase.Name, err)
 		}
-	default:
-		return &RequestError{
-			HTTPStatusCode: resp.StatusCode,
-			Err:            fmt.Errorf("unexpected content type: %s", contentType),
-		}
+	}
+}
+
+func TestClientReturnsRequestBuilderErrorsAddtion(t *testing.T) {
+	config := DefaultConfig(test.GetTestToken())
+	client := NewClientWithConfig(config)
+	client.requestBuilder = &failingRequestBuilder{}
+	ctx := context.Background()
+	_, err := client.CreateCompletion(ctx, CompletionRequest{Prompt: 1})
+	if !errors.Is(err, ErrCompletionRequestPromptTypeNotSupported) {
+		t.Fatalf("Did not return error when request builder failed: %v", err)
+	}
+	_, err = client.CreateCompletionStream(ctx, CompletionRequest{Prompt: 1})
+	if !errors.Is(err, ErrCompletionRequestPromptTypeNotSupported) {
+		t.Fatalf("Did not return error when request builder failed: %v", err)
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -195,7 +195,6 @@ func TestHandleJSONErrorResp(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			testCase := &http.Response{}
 			testCase.StatusCode = tc.httpCode
-			testCase.Header = http.Header{}
 			testCase.Body = io.NopCloser(tc.body)
 			err := client.handleErrorResp(testCase)
 			t.Log(err.Error())


### PR DESCRIPTION
Tracking issue: https://github.com/github/secret-scanning/issues/6050

**Describe the change**

Currently, the client is only set up to handle errors that are in JSON form. This PR updates the client to handle text errors as well.

I recommend reviewing the PR by hiding whitespace: https://github.com/odannyc/go-openai/pull/1/files?diff=split&w=1

The failing sanity checks are due to lint warnings that have nothing to do with the diff, so I'm ignoring them.