### PR TITLE
Handle errors with text/html content type in response

### DIFF
--- a/client.go
+++ b/client.go
@@ -245,10 +245,7 @@ func (c *Client) handleErrorResp(resp *http.Response) error {
 	contentType := resp.Header.Get("Content-Type")
 
 	if contentType != "" {
-		mainContentType := strings.Split(contentType, ";")[0]
-		mainContentType = strings.ToLower(strings.TrimSpace(mainContentType))
-
-		if mainContentType == "text/plain" {
+		if strings.Contains(contentType, "text") {
 			body, err := io.ReadAll(resp.Body)
 			if err != nil {
 				return err

--- a/client_test.go
+++ b/client_test.go
@@ -233,7 +233,7 @@ func TestHandleTextErrorResp(t *testing.T) {
 		{
 			name:        "401 Azure Access Denied",
 			httpCode:    http.StatusUnauthorized,
-			contentType: "text/plain",
+			contentType: "text/html",
 			body:        bytes.NewReader([]byte(`Access denied due to Virtual Network/Firewall rules.`)),
 			expected:    "error, status code: 401, message: Access denied due to Virtual Network/Firewall rules.",
 		},
@@ -247,7 +247,7 @@ func TestHandleTextErrorResp(t *testing.T) {
 		{
 			name:        "503 no message (Unknown response)",
 			httpCode:    http.StatusServiceUnavailable,
-			contentType: "text/plain",
+			contentType: "text/html",
 			body:        bytes.NewReader([]byte(``)),
 			expected:    "error, status code: 503, message: ",
 		},


### PR DESCRIPTION
Follow up to https://github.com/odannyc/go-openai/pull/1.

Updates error handling to handle all `text` content types - previously we were only dealing with `text/plain`.