### PR TITLE
Return 'Retry-After' header on 429

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -320,6 +320,9 @@ type ChatCompletionResponse struct {
 }
 
 // CreateChatCompletion — API call to Create a completion for the chat message.
+//
+// If the server returned 429 "Too Many Requests", then calling IsTooManyRequests on the error will return the value of the
+// "Retry-After" header.
 func (c *Client) CreateChatCompletion(
 	ctx context.Context,
 	request ChatCompletionRequest,

--- a/chat.go
+++ b/chat.go
@@ -321,8 +321,9 @@ type ChatCompletionResponse struct {
 
 // CreateChatCompletion — API call to Create a completion for the chat message.
 //
-// If the server returned 429 "Too Many Requests", then calling IsTooManyRequests on the error will return the value of the
-// "Retry-After" header.
+// If the server returned 429 "Too Many Requests", then calling
+// IsTooManyRequests on the error will return the value of the "Retry-After"
+// header.
 func (c *Client) CreateChatCompletion(
 	ctx context.Context,
 	request ChatCompletionRequest,

--- a/client.go
+++ b/client.go
@@ -241,6 +241,7 @@ func (c *Client) fullURL(suffix string, args ...any) string {
 	return fmt.Sprintf("%s%s", c.config.BaseURL, suffix)
 }
 
+// handleErrorResp returns either *RequestError or *APIError.
 func (c *Client) handleErrorResp(resp *http.Response) error {
 	contentType := resp.Header.Get("Content-Type")
 
@@ -253,6 +254,7 @@ func (c *Client) handleErrorResp(resp *http.Response) error {
 
 			return &RequestError{
 				HTTPStatusCode: resp.StatusCode,
+				HTTPRetryAfter: resp.Header.Get("Retry-After"),
 				Err:            fmt.Errorf("%s", body),
 			}
 		}
@@ -264,6 +266,7 @@ func (c *Client) handleErrorResp(resp *http.Response) error {
 	if err != nil || errRes.Error == nil {
 		reqErr := &RequestError{
 			HTTPStatusCode: resp.StatusCode,
+			HTTPRetryAfter: resp.Header.Get("Retry-After"),
 			Err:            err,
 		}
 		if errRes.Error != nil {
@@ -273,5 +276,6 @@ func (c *Client) handleErrorResp(resp *http.Response) error {
 	}
 
 	errRes.Error.HTTPStatusCode = resp.StatusCode
+	errRes.Error.HTTPRetryAfter = resp.Header.Get("Retry-After")
 	return errRes.Error
 }

--- a/client_test.go
+++ b/client_test.go
@@ -234,7 +234,6 @@ func TestHandleJSONErrorResp(t *testing.T) {
 				t.Errorf("(%s) Expected error to be of type APIError", tc.name)
 				t.Fail()
 			}
-
 		})
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -224,9 +224,18 @@ func TestHandleJSONErrorResp(t *testing.T) {
 				t.Fail()
 			}
 
-			_, retryAfter := IsTooManyRequests(err)
+			is429, retryAfter := IsTooManyRequests(err)
 			if tc.retryAfter != retryAfter {
 				t.Errorf("(%s) Expected error to have HTTPRetryAfter of \"%s\" but got \"%s\"", tc.name, tc.retryAfter, retryAfter)
+				t.Fail()
+			}
+			if tc.httpCode == http.StatusTooManyRequests && !is429 {
+				t.Errorf("(%s) Expected error to indicate 429, but it did not", tc.name)
+				t.Fail()
+			}
+			if tc.httpCode != http.StatusTooManyRequests && is429 {
+				t.Errorf("(%s) Expected error not to indicate 429, but it did", tc.name)
+				t.Fail()
 			}
 
 			e := &APIError{}
@@ -305,9 +314,17 @@ func TestHandleTextErrorResp(t *testing.T) {
 				t.Fail()
 			}
 
-			_, retryAfter := IsTooManyRequests(err)
+			is429, retryAfter := IsTooManyRequests(err)
 			if tc.retryAfter != retryAfter {
 				t.Errorf("(%s) Expected error to have HTTPRetryAfter of \"%s\" but got \"%s\"", tc.name, tc.retryAfter, retryAfter)
+			}
+			if tc.httpCode == http.StatusTooManyRequests && !is429 {
+				t.Errorf("(%s) Expected error to indicate 429, but it did not", tc.name)
+				t.Fail()
+			}
+			if tc.httpCode != http.StatusTooManyRequests && is429 {
+				t.Errorf("(%s) Expected error not to indicate 429, but it did", tc.name)
+				t.Fail()
 			}
 		})
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -133,10 +133,11 @@ func TestHandleJSONErrorResp(t *testing.T) {
 	client := NewClient(mockToken)
 
 	testCases := []struct {
-		name     string
-		httpCode int
-		body     io.Reader
-		expected string
+		name       string
+		httpCode   int
+		retryAfter string
+		body       io.Reader
+		expected   string
 	}{
 		{
 			name:     "401 Invalid Authentication",
@@ -189,6 +190,21 @@ func TestHandleJSONErrorResp(t *testing.T) {
 				}`)),
 			expected: "error, status code: 503, message: ",
 		},
+		{
+			name:       "429 too many requests",
+			httpCode:   http.StatusTooManyRequests,
+			retryAfter: "100",
+			body: bytes.NewReader([]byte(`
+			{
+				"error":{
+					"message": "Wow... you need to SLOW DOWN",
+					"type":"server_error",
+					"param":null,
+					"code":null
+				}
+			}`)),
+			expected: "error, status code: 429, message: Wow... you need to SLOW DOWN",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -196,6 +212,11 @@ func TestHandleJSONErrorResp(t *testing.T) {
 			testCase := &http.Response{}
 			testCase.StatusCode = tc.httpCode
 			testCase.Body = io.NopCloser(tc.body)
+			if len(tc.retryAfter) > 0 {
+				testCase.Header = http.Header{
+					"Retry-After": []string{tc.retryAfter},
+				}
+			}
 			err := client.handleErrorResp(testCase)
 			t.Log(err.Error())
 			if err.Error() != tc.expected {
@@ -203,11 +224,17 @@ func TestHandleJSONErrorResp(t *testing.T) {
 				t.Fail()
 			}
 
+			_, retryAfter := IsTooManyRequests(err)
+			if tc.retryAfter != retryAfter {
+				t.Errorf("(%s) Expected error to have HTTPRetryAfter of \"%s\" but got \"%s\"", tc.name, tc.retryAfter, retryAfter)
+			}
+
 			e := &APIError{}
 			if !errors.As(err, &e) {
 				t.Errorf("(%s) Expected error to be of type APIError", tc.name)
 				t.Fail()
 			}
+
 		})
 	}
 }
@@ -219,6 +246,7 @@ func TestHandleTextErrorResp(t *testing.T) {
 	testCases := []struct {
 		name        string
 		httpCode    int
+		retryAfter  string
 		contentType string
 		body        io.Reader
 		expected    string
@@ -251,6 +279,14 @@ func TestHandleTextErrorResp(t *testing.T) {
 			body:        bytes.NewReader([]byte(``)),
 			expected:    "error, status code: 503, message: ",
 		},
+		{
+			name:        "429 too many requests",
+			httpCode:    http.StatusTooManyRequests,
+			retryAfter:  "100",
+			contentType: "text/html",
+			body:        bytes.NewReader([]byte(`Wow... you need to slow down`)),
+			expected:    "error, status code: 429, message: Wow... you need to slow down",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -259,12 +295,20 @@ func TestHandleTextErrorResp(t *testing.T) {
 			testCase.StatusCode = tc.httpCode
 			testCase.Header = http.Header{}
 			testCase.Header.Set("Content-Type", tc.contentType)
+			if len(tc.retryAfter) > 0 {
+				testCase.Header.Set("Retry-After", tc.retryAfter)
+			}
 			testCase.Body = io.NopCloser(tc.body)
 			err := client.handleErrorResp(testCase)
 			t.Log(err.Error())
 			if err.Error() != tc.expected {
 				t.Errorf("Unexpected error: %v , expected: %s", err, tc.expected)
 				t.Fail()
+			}
+
+			_, retryAfter := IsTooManyRequests(err)
+			if tc.retryAfter != retryAfter {
+				t.Errorf("(%s) Expected error to have HTTPRetryAfter of \"%s\" but got \"%s\"", tc.name, tc.retryAfter, retryAfter)
 			}
 		})
 	}

--- a/completion.go
+++ b/completion.go
@@ -169,6 +169,9 @@ type CompletionResponse struct {
 //
 // If using a fine-tuned model, simply provide the model's ID in the CompletionRequest object,
 // and the server will use the model's parameters to generate the completion.
+//
+// If the server returned 429 "Too Many Requests", then calling IsTooManyRequests on the error will return the value of the
+// "Retry-After" header.
 func (c *Client) CreateCompletion(
 	ctx context.Context,
 	request CompletionRequest,

--- a/completion.go
+++ b/completion.go
@@ -170,8 +170,9 @@ type CompletionResponse struct {
 // If using a fine-tuned model, simply provide the model's ID in the CompletionRequest object,
 // and the server will use the model's parameters to generate the completion.
 //
-// If the server returned 429 "Too Many Requests", then calling IsTooManyRequests on the error will return the value of the
-// "Retry-After" header.
+// If the server returned 429 "Too Many Requests", then calling
+// IsTooManyRequests on the error will return the value of the "Retry-After"
+// header.
 func (c *Client) CreateCompletion(
 	ctx context.Context,
 	request CompletionRequest,

--- a/files_api_test.go
+++ b/files_api_test.go
@@ -152,6 +152,7 @@ func TestGetFileContentReturnError(t *testing.T) {
 	client, server, teardown := setupOpenAITestServer()
 	defer teardown()
 	server.RegisterHandler("/v1/files/deadbeef/content", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(w, wantErrorResp)
 	})


### PR DESCRIPTION
A similar PR may already be submitted!
Please search among the [Pull request](https://github.com/sashabaranov/go-openai/pulls) before creating one.

If your changes introduce breaking changes, please prefix the title of your pull request with "[BREAKING_CHANGES]". This allows for clear identification of such changes in the 'What's Changed' section on the release page, making it developer-friendly.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.

**Describe the change**

When the server returns 429 "Too Many Requests", we now set a new `HTTPRetryAfter` field in the error value containing the value of the "Retry-After" header. We add a new helper method, `IsTooManyRequests`, that takes errors and returns the "Retry-After" value, if it's set.

**Provide OpenAI documentation link**
N/A

**Describe your solution**

See above

**Tests**

Updated `TestHandleJSONErrorResp` and `TestHandleTextErrorResp`.